### PR TITLE
point main to dist/index.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "urbit-ob",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "4.1.3",
   "license": "MIT",
   "description": "Utilities for Hoon-style atom printing and conversion",
-  "main": "dist/index.js",
+  "main": "src/index.js",
+  "browser": {
+    "src/index.js": "./dist/index.js"
+  },
   "scripts": {
     "build": "mkdir -p dist && rollup -c rollup.config.js",
     "test": "nyc mocha --reporter spec",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,9 @@
 {
   "name": "urbit-ob",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "license": "MIT",
   "description": "Utilities for Hoon-style atom printing and conversion",
-  "main": "src/index.js",
-  "browser": {
-    "src/index.js": "dist/index.js"
-  },
+  "main": "dist/index.js",
   "scripts": {
     "build": "mkdir -p dist && rollup -c rollup.config.js",
     "test": "nyc mocha --reporter spec",


### PR DESCRIPTION
This PR is a fix for bundling issues experienced during integration work in Bridge. If this is approved, I will have to make a similar PR to urbit-key-generation. This is the only way I have found to resolve the current bundling issues in Bridge, since from what I can tell [Webpack does not support the browser field](https://github.com/webpack/webpack/issues/151). I'm also curious what the current need for Node-side use is.

- point `main` to `./dist/index.js`
- bump version