### PR TITLE
Patch up browser spec and bundle

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,12 @@
 # Changelog
 
+- 4.1.3 (2019-09-09)
+    * Further fixes to the 'browser' specification.  Uses the single-line
+      spec outlined in [1] that simply provides an entry point hint for
+      builders.
+
+      [1]: https://github.com/defunctzombie/package-browser-field-spec
+
 - 4.1.2 (2019-09-05)
     * Reverts change that likely caused the 'browser' specification in
       package.json to break.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "urbit-ob",
-  "version": "4.1.1",
+  "version": "4.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,10 @@
 {
   "name": "urbit-ob",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "license": "MIT",
   "description": "Utilities for Hoon-style atom printing and conversion",
   "main": "src/index.js",
-  "browser": {
-    "src/index.js": "dist/index.js"
-  },
+  "browser": "./dist/index.js",
   "scripts": {
     "build": "mkdir -p dist && rollup -c rollup.config.js",
     "test": "nyc mocha --reporter spec",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,8 @@ export default {
   input: 'src/index.js',
   output: {
     file: 'dist/index.js',
-    format: 'cjs',
+    format: 'umd',
+    name: "urbit-ob",
     exports: 'named'
   },
   plugins: [


### PR DESCRIPTION
(Seeks to replace #28, #29)

The `browser` field of `package.json` is specified [here](https://github.com/defunctzombie/package-browser-field-spec).  In particular, the simple form:

    "browser": "./dist/index.js"

provides a hint to builders that `./dist/index.js` should be considered the entry point to the library in a browser environment.  Of note, the `.` prefix on the path is mandatory.  This PR cleans up our `browser` field to ensure that, per the spec, it provides the intended hint.

This also bundles our browser build as a UMD module (in the same fashion browserify does), which is more appropriate for a browser environment.

I've tested this in a couple of downstream components, namely urbit-key-generation and Bridge (the latter of which requires *both* urbit-key-generation and urbit-ob) and it works as expected.